### PR TITLE
Add through (used in lib/search.js) 

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "npm-package-search" : "~0.1.0",
     "github-from-package" : "~0.0.0",
     "mkdirp" : "~0.3.4",
-    "request": "~2.12.0"
+    "request": "~2.12.0",
+    "through": "~2.1.0"
   },
   "devDependencies" : {
     "browserify" : "~1.16.6"


### PR DESCRIPTION
Sorry for not putting it into one request. Browserify site starts without it, but module search doesn't work.
