### PR TITLE
Edits to articles list: npm everywhere slides & revised 'add resources' text

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -366,12 +366,7 @@ document.body.appendChild(txt);</pre>
   
       <h2>
       <a name="add-resources" class="anchor" href="#add-resources"><span class="octicon octicon-link"></span></a>Add resources</h2>
-
-        <p><a href="https://github.com/learn-js/learn-js.github.com/blob/master/_posts/2013-11-24-browserify-resources.md">This post is open source</a>.
-          Add new resources to this list by forking the repository, making changes
-          and making a pull request. Here's the file in the site's repo: <a href="https://github.com/learn-js/learn-js.github.com/blob/master/_posts/2013-11-24-browserify-resources.md">github.com/learn-js/learn-js.github.com/blob/master/_posts/2013-11-24-browserify-resources.md</a>
-        </p>
-        <p>Or suggest a resource by adding an issue: <a href="https://github.com/learn-js/learn-js.github.com/issues">github.com/learn-js/learn-js.github.com/issues</a>.</p>
+        <p>You can add resources to this list! Check out <a href="https://github.com/substack/browserify-website">this site's GitHub repo</a>.</p>
     </div>
     
     <div id="preview-box">


### PR DESCRIPTION
I've had a couple of pull requests for revisions, and realized it would be annoying to maintain this list in two places, so my plan is to replace the list at the learnjs.io post with a link directing people to http://browserify.org/articles.

Does that seem good?
