### PR TITLE
Capitalize list items.

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@ console.log(unique(data));
         <div class="step">
           <ul>
             <li>
-              use many of the tens of thousands of modules on NPM in the browser
+              Use many of the tens of thousands of modules on NPM in the browser
             </li>
             <li>Use <a href="https://www.npmjs.org/package/watchify">watchify</a>, a browserify compatible caching bundler, for super-fast bundle rebuilds as you develop.</li>
             <li>Use <span>--debug</span> when creating bundles to have Browserify automatically include Source Maps for easy debugging.</li>
@@ -105,7 +105,7 @@ console.log(unique(data));
               node-isms work
             </li>
             <li>
-              get browser versions of the node core libraries
+              Get browser versions of the node core libraries
               <a href="http://nodejs.org/docs/latest/api/events.html">events</a>,
               <a href="http://nodejs.org/docs/latest/api/stream.html">stream</a>,
               <a href="http://nodejs.org/docs/latest/api/path.html">path</a>,


### PR DESCRIPTION
For consistency, all list items should start with capital letters, except for items that begin with code.
